### PR TITLE
Pin MongoDB provider version to 1.17 or earlier

### DIFF
--- a/module/project/versions.tf
+++ b/module/project/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = ">= 1.15.0"
+      version = ">= 1.15.0, < 1.18.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
MongoDB provider 1.18.0 removed support for the 'scheme' parameter in the [mongodbatlas_third_party_integration](https://registry.terraform.io/providers/mongodb/mongodbatlas/1.18.0/docs/resources/third_party_integration) resource (and may have made other breaking changes, too).

Pin the provider version from 1.15 through 1.17 to keep things working till this module can be updated to accommodate the breaking change.